### PR TITLE
Make unique_id more "unique"

### DIFF
--- a/mopidy/config_flow.py
+++ b/mopidy/config_flow.py
@@ -66,7 +66,7 @@ class MopidyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._host = user_input[CONF_HOST]
             self._port = user_input[CONF_PORT]
             self._name = user_input[CONF_NAME]
-            self._uuid = re.sub(r"[._-]+", "_", self._host)
+            self._uuid = re.sub(r"[._-]+", "_", self._host)+"_"+str(self._port)
 
             try:
                 await self.hass.async_add_executor_job(_validate_input, self._host, self._port)


### PR DESCRIPTION
Currently a user with multiple Mopidy instances on the same host is not able to configure more than one, due to the hostname and therefore the unique_id being the same. This fixes the unique_id by appending the port to the hostname.