### PR TITLE
#4 #5 fix warnings and zeroconf on docker

### DIFF
--- a/custom_components/mopidy/manifest.json
+++ b/custom_components/mopidy/manifest.json
@@ -1,10 +1,18 @@
 {
     "config_flow": true,
-    "codeowners": ["@bushvin"],
+    "codeowners": [
+        "@bushvin"
+    ],
     "domain": "mopidy",
     "documentation": "https://github.com/bushvin/hass-integrations#mopidy",
     "name": "Mopidy",
-    "requirements": ["mopidyapi==1.0.0"],
+    "requirements": [
+        "mopidyapi==1.0.0"
+    ],
     "version": "1.4.0",
-    "zeroconf": [{"type": "_http._tcp.local."}]
+    "zeroconf": [
+        {
+            "type": "_mopidy-http._tcp.local."
+        }
+    ]
 }


### PR DESCRIPTION
Hi,

First thanks a lot for this integration !

Here is a proposal to fix #4 and #5.

For #4, actually Mopidy publishes the "_mopidy-http._tcp.local." zeroconf so it's a good way to detect a Mopidy instance without trying to connect. I also removed the warnings in the logger which should not have any more  sense now.

For #5, the problem has been discussed a lot of times in Home Assistant integrations. Either the zeroconf service publishes an IP or a FQDN other than .local, in which case it can be used, either we just get the IP.  Even better, just after getting the IP, we reverse resolve it into the FQDN so the configuration remains stable even with an IP change of the device.

Thanks!