### PR TITLE
updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The playing queue is snapshotted
 
 |Service data attribute|Optional|Description|
 |-|-|-|
-|`entity_id`|no|String or list of `entiti_id`s that should have their snapshot restored.|
+|`entity_id`|no|String or list of `entity_id`s that should have their snapshot restored.|
 
 #### Service mopidy.search
 Search media based on keywords and add them to the queue. This service does not replace the queue, nor does it start playing the queue. This can be achieved through the use of [media\_player.clear\_playlist](https://www.home-assistant.io/integrations/media_player/) and [media\_player.media\_play](https://www.home-assistant.io/integrations/media_player/)
@@ -79,7 +79,7 @@ Search media based on keywords and add them to the queue. This service does not 
 
 |Service data attribute|Optional|Description|Example|
 |-|-|-|-|
-|`entity_id`|no|String or list of `entiti_id`s ito take a snapshot of.| |
+|`entity_id`|no|String or list of `entity_id`s ito take a snapshot of.| |
 |`exact`|yes|String. Should the search be an exact match|false|
 |`keyword`|yes|String. The keywords to search for. Will search all track fields.|Everlong|
 |`keyword_album`|yes|String. The keywords to search for in album titles.|From Mars to Sirius|
@@ -95,7 +95,7 @@ Take a snapshot of what is currently playing on one or more Mopidy Servers. This
 
 |Service data attribute|Optional|Description|
 |-|-|-|
-|`entity_id`|no|String or list of `entiti_id`s ito take a snapshot of.|
+|`entity_id`|no|String or list of `entity_id`s ito take a snapshot of.|
 
 
 ### Notes

--- a/custom_components/mopidy/manifest.json
+++ b/custom_components/mopidy/manifest.json
@@ -7,9 +7,9 @@
     "documentation": "https://github.com/bushvin/hass-integrations#mopidy",
     "name": "Mopidy",
     "requirements": [
-        "mopidyapi==1.0.0"
+        "mopidyapi>=1.0.0"
     ],
-    "version": "1.4.6",
+    "version": "1.4.7",
     "zeroconf": [
         {
             "type": "_mopidy-http._tcp.local."

--- a/custom_components/mopidy/media_player.py
+++ b/custom_components/mopidy/media_player.py
@@ -657,13 +657,15 @@ class MopidyMediaPlayerEntity(MediaPlayerEntity):
             media_type = spotify.resolve_spotify_media_type(media_type)
             media_id = spotify.spotify_uri_from_media_browser_url(media_id)
             media_uris = [media_id]
-        elif media_type == MEDIA_TYPE_PLAYLIST:
+        elif media_type == MEDIA_CLASS_PLAYLIST:
             playlist = self.client.playlists.lookup(media_id)
             self._currentplaylist = playlist.name
             if media_id.partition(":")[0] == "m3u":
                 media_uris = [t.uri for t in playlist.tracks]
             else:
                 media_uris = [media_id]
+        elif media_type == MEDIA_CLASS_DIRECTORY:
+            media_uris = [ el.uri for el in self.client.library.browse(media_id) ]
         else:
             media_uris = [media_id]
 

--- a/mopidy-CHANGELOG.md
+++ b/mopidy-CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.7] - 2022-09-24
+
+### Fixed
+
+- BUGFIX: playing mopidy-local "directory" resources (eg `artists/albums`) failed as the resource is not considered
+  a media source according to URI\_SCHEME\_REGEX
+- typo in the README.md
+
+### Added
+
+- support for mopidyapi>=1.0.0, no need to stay in the stoneage
+
 ## [1.4.6] - 2022-03-06
 ### Fixed
 - playing from local media (thanks, [koying](https://github.com/koying))


### PR DESCRIPTION
### Fixed

- BUGFIX: playing mopidy-local "directory" resources (eg `artists/albums`) failed as the resource is not considered
  a media source according to URI\_SCHEME\_REGEX
- typo in the README.md

### Added

- support for mopidyapi>=1.0.0, no need to stay in the stoneage