### PR TITLE
Fix error on startup when using yaml configuration

### DIFF
--- a/custom_components/mopidy/media_player.py
+++ b/custom_components/mopidy/media_player.py
@@ -177,7 +177,7 @@ class MopidyMediaPlayerEntity(MediaPlayerEntity):
         self.device_name = device_name
 
         if device_uuid is None:
-            self.device_uuid = re.sub(r"[._-]+", "_", self.device_hostname) + "_" + str(self.device_port)
+            self.device_uuid = re.sub(r"[._-]+", "_", self.speaker.hostname) + "_" + str(self.speaker.port)
         else:
             self.device_uuid = device_uuid
 


### PR DESCRIPTION
When using the integration with yaml configuration, the integration will not start:

```
2023-11-07 18:07:04.851 ERROR (MainThread) [homeassistant.components.media_player] Error while setting up mopidy platform for media_player
Traceback (most recent call last):
  File "/home/homeassistant/hass/lib/python3.11/site-packages/homeassistant/helpers/entity_platform.py", line 359, in _async_setup_platform
    await asyncio.shield(task)
  File "/home/homeassistant/.homeassistant/custom_components/mopidy/media_player.py", line 158, in async_setup_platform
    entity = MopidyMediaPlayerEntity(speaker, device_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/homeassistant/.homeassistant/custom_components/mopidy/media_player.py", line 180, in __init__
    self.device_uuid = re.sub(r"[._-]+", "_", self.device_hostname) + "_" + str(self.device_port)
                                              ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'MopidyMediaPlayerEntity' object has no attribute 'device_hostname'
```

I guessed the fix and tested it successfully.