### PR TITLE
Multiple fixes

### DIFF
--- a/custom_components/mopidy/manifest.json
+++ b/custom_components/mopidy/manifest.json
@@ -10,7 +10,7 @@
     "requirements": [
         "mopidyapi>=1.0.0"
     ],
-    "version": "2.2.0",
+    "version": "2.2.1",
     "zeroconf": [
         {
             "type": "_mopidy-http._tcp.local."

--- a/custom_components/mopidy/media_player.py
+++ b/custom_components/mopidy/media_player.py
@@ -450,17 +450,17 @@ class MopidyMediaPlayerEntity(MediaPlayerEntity):
         """Return entity specific state attributes"""
         attributes: dict[str, Any] = {}
 
-        if self.speaker.queue.position is not None:
-            attributes["queue_position"] = self.speaker.queue.position
-
-        if self.speaker.queue.size is not None:
-            attributes["queue_size"] = self.speaker.queue.size
-
         if self.speaker.consume_mode is not None:
             attributes["consume_mode"] = self.speaker.consume_mode
 
         if self.speaker.queue.current_track_extension is not None:
             attributes["mopidy_extension"] = self.speaker.queue.current_track_extension
+
+        if self.speaker.queue.position is not None:
+            attributes["queue_position"] = self.speaker.queue.position
+
+        if self.speaker.queue.size is not None:
+            attributes["queue_size"] = self.speaker.queue.size
 
         if self.speaker.snapshot_taken_at is not None:
             attributes["snapshot_taken_at"] = self.speaker.snapshot_taken_at

--- a/custom_components/mopidy/speaker.py
+++ b/custom_components/mopidy/speaker.py
@@ -269,16 +269,16 @@ class MopidyQueue:
         self.__set_track_info(tlid, track_info)
         if current:
             self._current_track_tlid = tlid
-            self._current_track_uri = track_info.get("uri")
-            self._current_track_album_artist = track_info.get("album_artist")
-            self._current_track_album_name = track_info.get("album_name")
-            self._current_track_artist = track_info.get("artist")
-            self._current_track_duration = track_info.get("duration")
-            self._current_track_extension = track_info.get("source")
-            self._current_track_playlist_name = track_info.get("playlist_name")
-            self._current_track_title = track_info.get("title")
-            self._current_track_is_stream = track_info.get("is_stream")
-            self._current_track_number = track_info.get("number")
+            self._current_track_uri = self.queue[tlid].get("uri")
+            self._current_track_album_artist = self.queue[tlid].get("album_artist")
+            self._current_track_album_name = self.queue[tlid].get("album_name")
+            self._current_track_artist = self.queue[tlid].get("artist")
+            self._current_track_duration = self.queue[tlid].get("duration")
+            self._current_track_extension = self.queue[tlid].get("source")
+            self._current_track_playlist_name = self.queue[tlid].get("playlist_name")
+            self._current_track_title = self.queue[tlid].get("title")
+            self._current_track_is_stream = self.queue[tlid].get("is_stream")
+            self._current_track_number = self.queue[tlid].get("number")
 
         return track_info
 
@@ -387,7 +387,7 @@ class MopidyQueue:
                     "playlist_name": res.name,
                     "playlist_uri": res.uri,
                 }
-                self.__set_track_info(tl_track.tlid, **track_info)
+                self.__set_track_info(tl_track.tlid, track_info)
 
     def update_queue_information(self, updater=None):
         """Get the Mopidy Instance queue information"""
@@ -809,14 +809,14 @@ class MopidySpeaker:
 
         elif enqueue == MediaPlayerEnqueue.NEXT:
             # Add media uris to queue after current playing track
-            index = self.queue_position
+            index = self.queue.position
             queued = self.queue_tracks(media_uris, at_position=index+1)
             if self.state != MediaPlayerState.PLAYING:
                 self.media_play()
 
         elif enqueue == MediaPlayerEnqueue.PLAY:
             # Insert media uris before current playing track into queue and play first of new uris
-            index = self.queue_position
+            index = self.queue.position
             queued = self.queue_tracks(media_uris, at_position=index)
             self.media_play(index)
 

--- a/custom_components/mopidy/speaker.py
+++ b/custom_components/mopidy/speaker.py
@@ -230,10 +230,12 @@ class MopidyQueue:
         parsed_url = urlparse.urlparse(url)
         if parsed_url.netloc == "":
             url = f"{self.local_url_base}{url}"
+
+        # Force the browser to reload the image once per day
         query = dict(urlparse.parse_qsl(parsed_url.query))
-        if query.get("t") is None:
+        if query.get("mopt") is None:
             url_parts = list(urlparse.urlparse(url))
-            query["t"] = int(time.time() * 1000)
+            query["mopt"] = datetime.datetime.now().strftime("%Y%m%d")
             url_parts[4] = urlencode(query)
             url = urlparse.urlunparse(url_parts)
 

--- a/mopidy-CHANGELOG.md
+++ b/mopidy-CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - expanding the url will add a timestamp based on the day instead of epoch, causing it to reload daily instead of every time the image is refreshed (which is every 10 seconds)
 - correct snapshotting variables/methods
 - alphabetize `extra_state_attributes` variables
+- retrieve the correct current track information
+- fix queue variables for `media_play`
 
 ## [2.2.0] - 2023-11-11
 

--- a/mopidy-CHANGELOG.md
+++ b/mopidy-CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [2.2.1] - 2023-11-13
 
-### Changed
+### Fixed
 
 - expanding the url will add a timestamp based on the day instead of epoch, causing it to reload daily instead of every time the image is refreshed (which is every 10 seconds)
+- correct snapshotting variables/methods
+- alphabetize `extra_state_attributes` variables
 
 ## [2.2.0] - 2023-11-11
 

--- a/mopidy-CHANGELOG.md
+++ b/mopidy-CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+
+- expanding the url will add a timestamp based on the day instead of epoch, causing it to reload daily instead of every time the image is refreshed (which is every 10 seconds)
+
 ## [2.2.0] - 2023-11-11
 
 ### Changed


### PR DESCRIPTION
- expanding the url will add a timestamp based on the day instead of epoch, causing it to reload daily instead of every time the image is refreshed (which is every 10 seconds)
- correct snapshotting variables/methods
- alphabetize `extra_state_attributes` variables
- retrieve the correct current track information
- fix queue variables for `media_play`


Should fix #55 and #57