### PR TITLE
New service: get search results instead of queueing them

### DIFF
--- a/custom_components/mopidy/const.py
+++ b/custom_components/mopidy/const.py
@@ -8,6 +8,7 @@ SERVICE_SET_CONSUME_MODE = "set_consume_mode"
 SERVICE_SNAPSHOT = "snapshot"
 SERVICE_RESTORE = "restore"
 SERVICE_SEARCH = "search"
+SERVICE_GET_SEARCH_RESULT = "get_search_result"
 CACHE_TITLES = {}
 CACHE_ART = {}
 YOUTUBE_URLS = [

--- a/custom_components/mopidy/services.yaml
+++ b/custom_components/mopidy/services.yaml
@@ -72,6 +72,62 @@ search:
       selector:
         text:
 
+get_search_result:
+  name: Get search result
+  description:
+    Search the mopidy library for audio and returns any URIs found.
+  target:
+    entity:
+      integration: mopidy
+      domain: media_player
+  fields:
+    exact:
+      name: Match exactly
+      description: Should the search be an exact match
+      example: "false"
+      default: false
+      selector:
+        boolean:
+    keyword:
+      name: Search keywords
+      description: The keywords to search for. Will search all track fields.
+      example: Everlong
+      selector:
+        text:
+    keyword_album:
+      name: Search album title
+      description: The keywords to search for in album titles.
+      example: From Mars to Sirius
+      selector:
+        text:
+    keyword_artist:
+      name: Search artist
+      description: The keywords to search for in artists.
+      example: Queens of the Stoneage
+      selector:
+        text:
+    keyword_genre:
+      name: Search genre
+      description: The keywords to search for in genres.
+      example: rock
+      selector:
+        text:
+    keyword_track_name:
+      name: Search track name
+      description: The keywords to search for in track names.
+      example: Lazarus
+      selector:
+        text:
+    source:
+      name: Limit search to source
+      description:
+        URI sources to search.
+        `local`, `spotify` and `tunein` are the only supported options. Make sure to have these extensions enabled on
+        your Mopidy Server! Separate multiple sources with a comma (,).
+      example: "local,spotify"
+      selector:
+        text:
+
 set_consume_mode:
   name: 'Set the mopidy consume mode'
   description:


### PR DESCRIPTION
I needed the search service to return the results instead of queueing them, so I made this modification. It's obviously backwards incompatible, but I wanted to compare notes with you first.

At first, I tried to have two birds with one stone: I used `SupportsResponse.OPTIONAL` but I couldn't find a way to receive the `ServiceCall` object from HA: only service parameters were always passed to the service method.
The `ServiceCall` object is needed to decide [whether the service should return a response or not](https://developers.home-assistant.io/docs/dev_101_services#supporting-response-data): using that, you could have a service that behaves both as an action and a function (i.e. something that returns data).

It could be a bug in HA (from https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/service.py#L942-L947):

```python
    # If the service function is a string, we'll pass it the service call data
    if isinstance(func, str):
        data: dict | ServiceCall = remove_entity_service_fields(call)
    # If the service function is not a string, we pass the service call
    else:
        data = call
```

From that point on, the `call: ServiceCall` object is lost, I think - at least I couldn't find it anywhere else in the flow until the actual service method is called. Am I missing something here? Could it really be a HA bug?

If passing `ServiceCall` wouldn't be supported by HA API in any way, I would go about writing another service (like `get_search_result` or something), keeping backwards compatibility with the existing `search` service.

What do you think?