### PR TITLE
Fix play media with 'play' enqueue parameter when stopped

### DIFF
--- a/custom_components/mopidy/speaker.py
+++ b/custom_components/mopidy/speaker.py
@@ -830,6 +830,11 @@ class MopidySpeaker:
         elif enqueue == MediaPlayerEnqueue.PLAY:
             # Insert media uris before current playing track into queue and play first of new uris
             index = self.queue.position
+            if index is None and self.queue.size is not None:
+                # no index, probably in stopped state;
+                # use the last element as index (if known);
+                # if all else fail, will play from the beginning
+                index = self.queue.size
             queued = self.queue_tracks(media_uris, at_position=index)
             self.media_play(index)
 


### PR DESCRIPTION
The current queue position while in stopped state is None. Issuing the play command to Mopidy with a None position will start playback from the beginning (failing to play the requested track, which was appended at the end of the queue).

This fix will fall back to appending tracks at the end of the queue if Mopidy is in stopped state.

Feel free to decide whether this is the right behavior in your view: since, while in stopped state Mopidy has no "currently playing track", adding a track "before the current one" doesn't really make much sense. For example, one could want to put the track at the beginning (meaning: opinions really).