### PR TITLE
Add dependency on spotifyaio

### DIFF
--- a/custom_components/mopidy/manifest.json
+++ b/custom_components/mopidy/manifest.json
@@ -8,7 +8,8 @@
     "issue_tracker": "https://github.com/bushvin/hass-integrations/issues",
     "name": "Mopidy",
     "requirements": [
-        "mopidyapi>=1.1.0"
+        "mopidyapi>=1.1.0",
+        "spotifyaio==0.9.0"
     ],
     "version": "2.4.1",
     "zeroconf": [


### PR DESCRIPTION
It was missing in the manifest. I fixed to a specific version because semantic versioning compatibility rules (assuming the devs of python-spotify are following them) don't apply for 0.* versions.

Tested on Home Assistant 2025.2.0.