### PR TITLE
Fix state update failing: track_no is None

### DIFF
--- a/custom_components/mopidy/speaker.py
+++ b/custom_components/mopidy/speaker.py
@@ -251,7 +251,7 @@ class MopidyQueue:
             track_info["uri"] = track.uri
             track_info["source"] = track.uri.partition(":")[0]
 
-        if hasattr(track, "track_no"):
+        if hasattr(track, "track_no") and track.track_no is not None:
             track_info["number"] = int(track.track_no)
 
         if hasattr(track, "length"):


### PR DESCRIPTION
I was getting these exceptions during every state update:
```
2025-10-01 19:07:16.540 ERROR (MainThread) [homeassistant.helpers.entity] Update for media_player.mopidy_ondra fails
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 963, in async_update_ha_state
    await self.async_device_update()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1316, in async_device_update
    await hass.async_add_executor_job(self.update)
  File "/usr/local/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/mopidy/media_player.py", line 550, in update
    self.speaker.update()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/config/custom_components/mopidy/speaker.py", line 990, in update
    self.queue.update()
    ~~~~~~~~~~~~~~~~~^^
  File "/config/custom_components/mopidy/speaker.py", line 312, in update
    self.update_current_track()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/config/custom_components/mopidy/speaker.py", line 326, in update_current_track
    track_info = self.parse_track_info(
        track=current_track.track,
        tlid=current_track.tlid,
        current=True
        )
  File "/config/custom_components/mopidy/speaker.py", line 255, in parse_track_info
    track_info["number"] = int(track.track_no)
                           ~~~^^^^^^^^^^^^^^^^
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

This PR fixes it.
(I am running Mopidy 4.0.0a4).